### PR TITLE
Specify contentType in ajax POST request.

### DIFF
--- a/mentoring/public/js/mentoring.js
+++ b/mentoring/public/js/mentoring.js
@@ -85,7 +85,14 @@ function MentoringBlock(runtime, element) {
                 }
             }
             var handlerUrl = runtime.handlerUrl(element, 'submit');
-            $.post(handlerUrl, JSON.stringify(data)).success(handleSubmitResults);
+            $.ajax(handlerUrl, {
+                type: 'POST',
+                // Set contentType to prevent jQuery from modifying the JSON data.
+                // (see: http://bugs.jquery.com/ticket/8417)
+                contentType: 'application/json; charset: UTF-8',
+                data: JSON.stringify(data),
+                success: handleSubmitResults
+            });
         });
 
         if (submit_dom.length) {


### PR DESCRIPTION
Set content type to 'application/json' when POSTing JSON data to the server.

This fixes a bug where any occurence of the '??' string in POSTeda answer data
would get replaced with a random jsonp callback name generated by jQuery.

If content type is set to something other than the default www-form-urlencoded,
jQuery will not mess with the data.

cf. http://bugs.jquery.com/ticket/8417
