### PR TITLE
Remove serialize_opaque_key

### DIFF
--- a/mentoring/answer.py
+++ b/mentoring/answer.py
@@ -31,8 +31,7 @@ from xblock.fragment import Fragment
 
 from .light_children import LightChild, Boolean, Scope, String
 from .models import Answer
-from .utils import render_template, serialize_opaque_key
-
+from .utils import render_template
 
 # Globals ###########################################################
 
@@ -134,7 +133,7 @@ class AnswerBlock(LightChild):
 
         # TODO: Why do we need to use `xmodule_runtime` and not `runtime`?
         student_id = self.xmodule_runtime.anonymous_student_id
-        course_id = serialize_opaque_key(self.xmodule_runtime.course_id)
+        course_id = self.xmodule_runtime.course_id
 
         answer_data, created = Answer.objects.get_or_create(
             student_id=student_id,

--- a/mentoring/light_children.py
+++ b/mentoring/light_children.py
@@ -40,7 +40,7 @@ except:
     # TODO-WORKBENCH-WORKAROUND: To allow to load from the workbench
     replace_jump_to_id_urls = lambda a,b,c,d,frag,f: frag
 
-from .utils import serialize_opaque_key, XBlockWithChildrenFragmentsMixin
+from .utils import XBlockWithChildrenFragmentsMixin
 
 
 # Globals ###########################################################
@@ -179,7 +179,7 @@ class XBlockWithLightChildren(LightChildrenMixin, XBlock):
         """
         # TODO: Why do we need to use `xmodule_runtime` and not `runtime`?
         try:
-            course_id = serialize_opaque_key(self.xmodule_runtime.course_id)
+            course_id = self.xmodule_runtime.course_id
         except AttributeError:
             # TODO-WORKBENCH-WORKAROUND: To allow to load from the workbench
             course_id = 'sample-course'

--- a/mentoring/utils.py
+++ b/mentoring/utils.py
@@ -82,28 +82,6 @@ def load_scenarios_from_path(scenarios_path):
     """
     return get_scenarios_from_path(scenarios_path, include_identifier=True)
 
-def serialize_opaque_key(key):
-    """
-    Gracefully handle opaque keys, both before and after the transition.
-    https://github.com/edx/edx-platform/wiki/Opaque-Keys
-
-    From https://github.com/edx/edx-ora2/pull/330
-
-    Currently uses `to_deprecated_string()` to ensure that new keys
-    are backwards-compatible with keys we store in ORA2 database models.
-
-    Args:
-    key (unicode or OpaqueKey subclass): The key to serialize.
-
-    Returns:
-    unicode
-
-    """
-    if hasattr(key, 'to_deprecated_string'):
-        return key.to_deprecated_string()
-    else:
-        return unicode(key)
-
 
 # Classes ###########################################################
 


### PR DESCRIPTION
This pull request addresses the comments in #2. The `serialize_opaque_key` method has been removed, since the handling of deprecated keys and opaque keys is now handled automatically by `OpaqueKey. __unicode__()` in `opaque-keys/opaque_keys/__init__.py`.
